### PR TITLE
operators [O] kubeturbo (8.3.3)

### DIFF
--- a/operators/kubeturbo/8.3.3/kubeturbo-operator.v8.3.3.clusterserviceversion.yaml
+++ b/operators/kubeturbo/8.3.3/kubeturbo-operator.v8.3.3.clusterserviceversion.yaml
@@ -11,6 +11,11 @@ metadata:
     description: Turbonomic Workload Automation for Multicloud simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.
     repository: https://github.com/turbonomic/kubeturbo/tree/master/deploy/kubeturbo-operator
     support: Turbonomic, Inc.
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: kubeturbo-operator.v8.3.3
   namespace: placeholder
 spec:


### PR DESCRIPTION
This is necessary for an operator to be displayed in the OpenShift web console OperatorHub on non-x86 architectures.
